### PR TITLE
Old Tweet Download Tool

### DIFF
--- a/classes/aktt.php
+++ b/classes/aktt.php
@@ -739,6 +739,55 @@ class AKTT {
 			}
 		}
 	}
+
+	/**
+	 * Imports old tweets based on settings submitted via the form
+	 *
+	 * @return void
+	 */
+	function import_old_tweets() {
+		$error = false;
+
+		if (empty($_POST['aktt_number_of_tweets']) || !is_numeric($_POST['aktt_number_of_tweets'])) {
+			$error = __('Please enter the number of tweets to download.', 'twitter-tools');
+		}
+		elseif ($_POST['aktt_number_of_tweets'] > 200) {
+			$error = __('Please enter a number under 200. Twitter&#8217;s API limits the download to 200 tweets.', 'twitter-tools');
+		}
+		elseif (empty($_POST['aktt_tweet_id']) || !is_numeric($_POST['aktt_tweet_id'])) {
+			$error = __('Please enter a valid tweet ID.', 'twitter-tools');
+		}
+		elseif (empty($_POST['aktt_account_id']) || !is_numeric($_POST['aktt_account_id'])) {
+			$error = __('Please select an account.', 'twitter-tools');
+		}
+		else {
+			$acct_id = intval($_POST['aktt_account_id']);
+			self::get_social_accounts();
+			if (!isset(self::$accounts[$acct_id])) {
+				$error = __('Account submitted not found.', 'twitter-tools');
+			}
+		}
+
+		if ($error) {
+			echo json_encode(array(
+				'result' => 'error',
+				'msg' => $error
+			));
+			return;
+		}
+
+		$max_id = $_POST['aktt_tweet_id'];
+		$number_of_tweets = $_POST['aktt_number_of_tweets'];
+
+		if ($tweets = self::$accounts[$acct_id]->download_tweets($max_id, $number_of_tweets)) {
+			self::$accounts[$acct_id]->save_tweets($tweets);
+		}
+
+		echo json_encode(array(
+			'result' => 'success',
+			'msg' => __('Tweets downloaded successfully.', 'twitter-tools')
+		));
+	}
 	
 	/**
 	 * Iterates over all the twitter accounts in social and downloads and imports the tweets.
@@ -926,6 +975,15 @@ class AKTT {
 	function admin_controller(){
 		if (isset($_GET['aktt_action'])) {
 			switch ($_GET['aktt_action']) {
+				case 'old_tweet_download':
+					// Permission & nonce checking
+					if (!check_admin_referer('old_tweet_download') || !current_user_can(self::$cap_download)) { 
+						wp_die(__('Sorry, try again.', 'twitter-tools'));
+					}
+
+					self::import_old_tweets();
+					die();
+					break;
 				case 'manual_tweet_download':
 					// Permission & nonce checking
 					if (!check_admin_referer('manual_tweet_download') || !current_user_can(self::$cap_download)) { 

--- a/classes/aktt_account.php
+++ b/classes/aktt_account.php
@@ -129,13 +129,23 @@ class AKTT_Account {
 	}
 	
 	
-	function download_tweets() {
-		// Use Social to download tweets for this account
-		$response = $this->service->request($this->social_acct, '1.1/statuses/user_timeline', array(
-			'count' => apply_filters('aktt_account_api_download_count', 20), // default to twitter's default 
+	function download_tweets($max_id = false, $count = false) {
+		if (false === $count) {
+			$count = apply_filters('aktt_account_api_download_count', 20);
+		}
+
+		$args = array(
+			'count' => $count, // default to twitter's default 
 			'include_entities' => 1, // include explicit hashtags and mentions
 			'include_rts' => 1, // include retweets
-		));
+		);
+
+		if (false !== $max_id ) {
+			$args['max_id'] = $max_id;
+		}
+
+		// Use Social to download tweets for this account
+		$response = $this->service->request($this->social_acct, '1.1/statuses/user_timeline', $args);
 		if ($response !== false) {
 			$content = $response->body();
 			if ($content->result == 'success') {

--- a/views/admin.php
+++ b/views/admin.php
@@ -94,6 +94,16 @@ table.form-table .depends-on-create-posts .help {
 .aktt-manual-update-running {
 	margin-left: 10px;
 }
+.aktt-old-tweet-download-result {
+	font-weight: bold;
+}
+.aktt-old-tweet-download-result .error {
+	color: red;
+}
+.aktt-old-tweet-download-spinner {
+	vertical-align: middle;
+	margin-left: 10px;
+}
 </style>
 <div class="wrap" id="<?php echo AKTT::$prefix.'options_page'; ?>">
 	<?php screen_icon(); ?>
@@ -186,13 +196,34 @@ if (AKTT::$enabled) {
 		<input type="submit" class="button-primary" value="<?php _e('Save Settings', 'twitter-tools'); ?>" />
 	</form>
 
-	<h3><?php _e('Download Tweets', 'twitter-tools'); ?></h3>
+	<h3><?php _e('Download Latest Tweets', 'twitter-tools'); ?></h3>
 	<p>
 		<?php _e('Tweets are downloaded automatically every 15 minutes. Can\'t wait?', 'twitter-tools'); ?>
 		<a href="<?php echo esc_url(AKTT::get_manual_update_url()); ?>" class="aktt-manual-update button-secondary"><?php _e('Download Tweets Now', 'twitter-tools'); ?></a>
 		<span class="aktt-manual-update-running"></span>
 		<img alt="" class="aktt-manual-update-request" src="<?php echo admin_url('images/wpspin_light.gif'); ?>">
 	</p>
+
+	<h3><?php _e('Download Old Tweets', 'twitter-tools'); ?></h3>
+	<form action="<?php echo add_query_arg( 'aktt_action', 'old_tweet_download', admin_url('index.php') ); ?>" method="post" class="aktt-old-tweet-download">
+	<?php wp_nonce_field('old_tweet_download'); ?>
+	Import the
+	<input type="number" name="aktt_number_of_tweets" value="20" style="width: 50px;" />
+	tweets posted <strong>before</strong> tweet #
+	<input type="number" size="15" name="aktt_tweet_id" placeholder="Tweet ID" />
+	for account
+	<select name="aktt_account_id">
+	<option value="">- Select an Account -</option>
+	<?php
+	foreach (self::$accounts as $account) {
+		printf( '<option value="%s">%s</option>', $account->id, esc_html($account->social_acct->name()));
+	}
+	?>
+	</select>
+	<button class="button-secondary" type="submit" style="vertical-align:middle;">Go</button>
+	<img style="display: none;" alt="" class="aktt-old-tweet-download-spinner" src="<?php echo admin_url('images/wpspin_light-2x.gif'); ?>" width="16" height="16">
+	</form>
+	<div class="aktt-old-tweet-download-result"></div>
 
 <?php
 }
@@ -262,6 +293,24 @@ jQuery(function($) {
 			},
 			'json'
 		);
+	});
+	$('.aktt-old-tweet-download').submit(function(e) {
+		e.preventDefault();
+				
+		var $spinner = $('.aktt-old-tweet-download-spinner'),
+			$result = $('.aktt-old-tweet-download-result');
+		
+		$spinner.show();
+		$result.hide();
+
+		var $form = $(this),
+			data = $form.serialize();
+			url = $form.attr('action');
+		$.post(url, data, function (response) {
+			var message = '<p class="' + response.result + '">' + response.msg + '</p>';
+			$spinner.hide();
+			$result.html(message).fadeIn();
+		}, 'json');
 	});
 });
 </script>


### PR DESCRIPTION
From time to time, Twitter Tools has stopped working for whatever reason. Often times it's a change to the Twitter API that requires an update to Social and Twitter Tools and by the time I update the plugins, it has missed a bunch of tweets. I had just ignored this until now and so have little patches of tweets missing in my history.

This tool allows you to fill in those patches by giving the tweet ID to start at and how many tweets before that to import.
