### PR TITLE
Added 'aktt_follow_text' filter to "Follow Me on Twitter" text

### DIFF
--- a/views/widget.php
+++ b/views/widget.php
@@ -3,7 +3,7 @@
 include('tweet-list.php');
 
 ?>
-	<p class="aktt_more_updates"><a href="<?php echo esc_url(AKTT::profile_url($username)); ?>"><?php _e('Follow Me on Twitter', 'twitter-tools'); ?></a></p>
+	<p class="aktt_more_updates"><a href="<?php echo esc_url(AKTT::profile_url($username)); ?>"><?php echo apply_filters( 'aktt_follow_text', __('Follow Me on Twitter', 'twitter-tools') ); ?></a></p>
 <?php
 if (AKTT::option('credit')) {
 ?>


### PR DESCRIPTION
I've added the `aktt_follow_text` filter to the "Follow Me on Twitter" text in `views/widget.php`. This allows us to modify the "Me" to "Us", when the twitter account is a company account. We use it like so:

```
function aktt_filter_follow_text() {
  return __( 'Follow us on Twitter', 'uf' );
}
add_filter( 'aktt_follow_text', 'aktt_filter_follow_text' );
```
