### PR TITLE
Added an option to determine where to add any images

### DIFF
--- a/classes/aktt.php
+++ b/classes/aktt.php
@@ -115,6 +115,17 @@ class AKTT {
 					'0' => __('No', 'twitter-tools')
 				),
 			),
+			'image_placement' => array(
+				'name' => 'image_placement',
+				'value' => 0,
+				'label' => __('Image placement in posts', 'twitter-tools'),
+				'type' => 'radio',
+				'options' => array(
+					'0' => __('In post content and as featured image (default)', 'twitter-tools'),
+					'1' => __('Only in post content', 'twitter-tools'),
+					'2' => __('Only as featured image', 'twitter-tools'),
+				),
+			),
 			'credit' => array(
 				'name' => 'credit',
 				'value' => 1,
@@ -395,7 +406,7 @@ class AKTT {
 				$post->tweet = new AKTT_Tweet(json_decode($raw_data));
 				$post->post_content = $post->tweet->link_entities();
 			}
-			if (has_post_thumbnail($post->ID)) {
+			if (has_post_thumbnail($post->ID) && (self::option('image_placement') == 0 || self::option('image_placement') == 1)) {
 				$size = apply_filters('aktt_featured_image_size', 'medium');
 				$post->post_content .= "\n\n".get_the_post_thumbnail(null, $size);
 			}

--- a/classes/aktt_tweet.php
+++ b/classes/aktt_tweet.php
@@ -520,7 +520,7 @@ class AKTT_Tweet {
 
 		// if there is a photo, add it
 		$this->featured_image_id = $this->sideload_image();
-		if (!empty($this->featured_image_id)) {
+		if (!empty($this->featured_image_id) && (AKTT::option('image_placement') == 0 || AKTT::option('image_placement') == 2)) {
 			update_post_meta($this->post_id, '_thumbnail_id', $this->featured_image_id);
 		}
 		
@@ -569,7 +569,7 @@ class AKTT_Tweet {
 
 		$post_content = $this->link_entities(false);
 		// Append image to post if there is one, can't set it as a featured image until after save
-		if (!empty($this->featured_image_id)) {
+		if (!empty($this->featured_image_id) && (AKTT::option('image_placement') == 0 || AKTT::option('image_placement') == 1)) {
 			$size = apply_filters('aktt_featured_image_size', 'medium');
 			$post_content .= "\n\n".wp_get_attachment_image($this->featured_image_id, $size);
 		}
@@ -617,7 +617,7 @@ class AKTT_Tweet {
 			set_post_format($this->blog_post_id, $post_format);
 		}
 		
-		if (!empty($this->featured_image_id)) {
+		if (!empty($this->featured_image_id) && (AKTT::option('image_placement') == 0 || AKTT::option('image_placement') == 2)) {
 			update_post_meta($this->blog_post_id, '_thumbnail_id', $this->featured_image_id);
 		}
 


### PR DESCRIPTION
This PR adds a new option to Tweet Tools that lets you configure how to attach any images contained in the tweet.

The options are: 
- In post content and as featured image (default)
- Only in post content
- Only as featured image

This provides more flexibility with some themes.
